### PR TITLE
Add devel dep test unit

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 rvm:
  - 1.9.3
  - 2.0.0
+ - 2.1
+ - 2.2
 
 script: bundle exec rake test

--- a/fluent-plugin-hipchat.gemspec
+++ b/fluent-plugin-hipchat.gemspec
@@ -22,4 +22,5 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency "simplecov", ">= 0.5.4"
   gem.add_development_dependency "rr", ">= 1.0.0"
   gem.add_development_dependency "pry"
+  gem.add_development_dependency "test-unit", ">= 3.1.0"
 end


### PR DESCRIPTION
Because Ruby 2.2 dose not provide minitest with test-unit compatible API.