### PR TITLE
Add a secret parameter

### DIFF
--- a/lib/fluent/plugin/out_hipchat.rb
+++ b/lib/fluent/plugin/out_hipchat.rb
@@ -5,7 +5,7 @@ module Fluent
     FORMAT = %w(html text)
     Fluent::Plugin.register_output('hipchat', self)
 
-    config_param :api_token, :string
+    config_param :api_token, :string, :secret => true
     config_param :default_room, :string, :default => nil
     config_param :default_color, :string, :default => nil
     config_param :default_from, :string, :default => nil


### PR DESCRIPTION
Fluentd 0.12.13 or later supports secret parameter feature.
https://github.com/fluent/fluentd/blob/4e3a4ecb/ChangeLog#L34

This feature works as below:

```log
  <match hipchat>
    type hipchat
    api_token xxxxxx
    default_room my_room
    default_from fluentd
    default_color yellow
    default_notify 0
    default_format html
    default_timeout 3
    key_name message
  </match>
</ROOT>
```