### PR TITLE
Specify more default values in config_param

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,8 @@
 rvm:
- - 1.9.3
- - 2.0.0
  - 2.1
  - 2.2
-
-script: bundle exec rake test
+ - 2.3.3
+before_install:
+ - gem update bundler
+script:
+ - bundle exec rake test

--- a/fluent-plugin-hipchat.gemspec
+++ b/fluent-plugin-hipchat.gemspec
@@ -23,4 +23,5 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency "rr", ">= 1.0.0"
   gem.add_development_dependency "pry"
   gem.add_development_dependency "test-unit", ">= 3.1.0"
+  gem.add_development_dependency "test-unit-rr", ">= 1.0.5"
 end

--- a/lib/fluent/plugin/out_hipchat.rb
+++ b/lib/fluent/plugin/out_hipchat.rb
@@ -7,10 +7,10 @@ module Fluent
 
     config_param :api_token, :string, :secret => true
     config_param :default_room, :string, :default => nil
-    config_param :default_color, :string, :default => nil
-    config_param :default_from, :string, :default => nil
-    config_param :default_notify, :bool, :default => nil
-    config_param :default_format, :string, :default => nil
+    config_param :default_color, :string, :default => 'yellow'
+    config_param :default_from, :string, :default => 'fluentd'
+    config_param :default_notify, :bool, :default => false
+    config_param :default_format, :string, :default => 'html'
     config_param :key_name, :string, :default => 'message'
     config_param :default_timeout, :time, :default => nil
     config_param :http_proxy_host, :string, :default => nil
@@ -31,10 +31,7 @@ module Fluent
 
       @hipchat = HipChat::API.new(conf['api_token'])
       @default_room = conf['default_room']
-      @default_from = conf['default_from'] || 'fluentd'
       @default_notify = conf['default_notify'] || 0
-      @default_color = conf['default_color'] || 'yellow'
-      @default_format = conf['default_format'] || 'html'
       @default_timeout = conf['default_timeout']
       if conf['http_proxy_host']
         HipChat::API.http_proxy(

--- a/test/plugin/out_hipchat.rb
+++ b/test/plugin/out_hipchat.rb
@@ -27,6 +27,19 @@ class HipchatOutputTest < Test::Unit::TestCase
     }.configure(conf)
   end
 
+  def test_configure_default
+    d = create_driver %[
+      type hipchat
+      api_token testtoken
+    ]
+    assert_equal "yellow", d.instance.default_color
+    assert_equal "fluentd", d.instance.default_from
+    assert_equal 0, d.instance.default_notify
+    assert_equal "html", d.instance.default_format
+    assert_equal "message", d.instance.key_name
+    assert_equal 1, d.instance.flush_interval
+  end
+
   def test_default_message
     d = create_driver(<<-EOF)
                       type hipchat

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,12 +1,6 @@
 $LOAD_PATH.unshift(File.join(File.dirname(__FILE__), '..', 'lib'))
 $LOAD_PATH.unshift(File.dirname(__FILE__))
 
-require 'rr'
-require 'test/unit'
-class Test::Unit::TestCase
-  include RR::Adapters::TestUnit
-end
-
 if ENV['SIMPLE_COV']
   require 'simplecov'
   SimpleCov.start do

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -17,4 +17,5 @@ if ENV['SIMPLE_COV']
 end
 
 require 'test/unit'
+require 'test/unit/rr'
 require 'fluent/test'


### PR DESCRIPTION
If default values specified in :default,
users can obtain default values via `--show-plugin-config output:hipchat` option as
follows:

```log
api_token: string: <nil>
default_room: string: <nil>
default_color: string: <"yellow">
default_from: string: <"fluentd">
default_notify: bool: <false>
default_format: string: <"html">
key_name: string: <"message">
default_timeout: time: <nil>
http_proxy_host: string: <nil>
http_proxy_port: integer: <nil>
http_proxy_user: string: <nil>
http_proxy_pass: string: <nil>
flush_interval: time: <1>
```