### PR TITLE
Migrate to use v0.14 API

### DIFF
--- a/fluent-plugin-hipchat.gemspec
+++ b/fluent-plugin-hipchat.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |gem|
   gem.executables = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
   gem.require_paths = ['lib']
 
-  gem.add_dependency "fluentd", ">= 0.10.8"
+  gem.add_dependency "fluentd", [">= 0.14.0", "< 2"]
   gem.add_dependency "hipchat-api",  ">= 1.0.0"
 
   gem.add_development_dependency "rake", ">= 0.9.2"

--- a/lib/fluent/plugin/out_hipchat.rb
+++ b/lib/fluent/plugin/out_hipchat.rb
@@ -71,7 +71,7 @@ module Fluent::Plugin
           send_message(record) if record[@key_name]
           set_topic(record) if record['topic']
         rescue => e
-          $log.error("HipChat Error:", :error_class => e.class, :error => e.message)
+          log.error("HipChat Error:", :error_class => e.class, :error => e.message)
         end
       end
     end

--- a/lib/fluent/plugin/out_hipchat.rb
+++ b/lib/fluent/plugin/out_hipchat.rb
@@ -54,7 +54,7 @@ module Fluent::Plugin
     end
 
     def format(tag, time, record)
-      [tag, time, record].to_msgpack
+      [time, record].to_msgpack
     end
 
     def formatted_to_msgpack_binary
@@ -66,7 +66,7 @@ module Fluent::Plugin
     end
 
     def write(chunk)
-      chunk.msgpack_each do |(tag,time,record)|
+      chunk.msgpack_each do |(time,record)|
         begin
           send_message(record) if record[@key_name]
           set_topic(record) if record['topic']

--- a/test/plugin/out_hipchat.rb
+++ b/test/plugin/out_hipchat.rb
@@ -42,6 +42,17 @@ class HipchatOutputTest < Test::Unit::TestCase
     assert_equal 1, d.instance.flush_interval
   end
 
+  def test_format
+    d = create_driver
+    stub(d.instance.hipchat).rooms_message('testroom', 'testuser', 'foo', 0, 'red', 'html')
+    assert_equal d.instance.hipchat.instance_variable_get(:@token), 'testtoken'
+    time = event_time
+    d.run(default_tag: "test") do
+      d.feed(time, {'message' => 'foo', 'color' => 'red'})
+    end
+    assert_equal ["test", time, {'message' => 'foo', 'color' => 'red'}].to_msgpack, d.formatted[0]
+  end
+
   def test_default_message
     d = create_driver(<<-EOF)
                       type hipchat

--- a/test/plugin/out_hipchat.rb
+++ b/test/plugin/out_hipchat.rb
@@ -50,7 +50,7 @@ class HipchatOutputTest < Test::Unit::TestCase
     d.run(default_tag: "test") do
       d.feed(time, {'message' => 'foo', 'color' => 'red'})
     end
-    assert_equal ["test", time, {'message' => 'foo', 'color' => 'red'}].to_msgpack, d.formatted[0]
+    assert_equal [time, {'message' => 'foo', 'color' => 'red'}].to_msgpack, d.formatted[0]
   end
 
   def test_default_message

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -13,3 +13,5 @@ end
 require 'test/unit'
 require 'test/unit/rr'
 require 'fluent/test'
+require 'fluent/test/driver/output'
+require 'fluent/test/helpers'


### PR DESCRIPTION
If fluentd plugins use and inherits its class v0.14 API, Fluentd permits to change output plugin behavior with config.
In more detail, please refer to this article: http://www.clear-code.com/blog/2016/10/20.html
If this patches are acceptable for you, please review carefully and follow this upgrading from v0.12 (old style) guideline: http://docs.fluentd.org/v0.14/articles/plugin-update-from-v12

Sincerely,